### PR TITLE
crash where there are extra commas

### DIFF
--- a/src/pywinctl/_pywinctl_macos.py
+++ b/src/pywinctl/_pywinctl_macos.py
@@ -80,7 +80,11 @@ def getActiveWindow(app: AppKit.NSApplication = None):
                 end run"""
         proc = subprocess.Popen(['osascript'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding='utf8')
         ret, err = proc.communicate(cmd)
-        appName, title = ret.replace("\n", "").split(", ")
+        # sometimes the title of the window contains ',' characters, so just get the first entry as the appName and join the rest
+        # back together as a string
+        entries = ret.replace("\n", "").split(", ")
+        appName = entries[0]
+        title = ", ".join(entries[1:])
         if appName and title:
             apps = _getAllApps()
             for app in apps:


### PR DESCRIPTION
Turns out Google Chrome's Title will be whatever a webpage uses, as well as some information about the user. 
```
>>> import pywinctl as pwc
>>> win = pwc.getWindowsWithTitle('Cable and Satellite Tools - Distributor of Tools for CATV, Satellite, Home Theater, Security, Telecom - Google Chrome - Name (Person 1)')
>>> win[0].activate()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".local/share/virtualenvs/lib/python3.9/site-packages/pywinctl/_pywinctl_macos.py", line 725, in activate
    return self.isActive
  File ".local/share/virtualenvs/lib/python3.9/site-packages/pywinctl/_pywinctl_macos.py", line 1094, in isActive
    active = getActiveWindow()
  File ".local/share/virtualenvs/lib/python3.9/site-packages/pywinctl/_pywinctl_macos.py", line 83, in getActiveWindow
    appName, title = ret.replace("\n", "").split(", ")
ValueError: too many values to unpack (expected 2)
```
The code change fixes this.