### PR TITLE
Fix pynput version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "pywin32>=302; sys_platform == 'win32'",
         "xlib~=0.21; sys_platform == 'linux'",
         "ewmh~=0.1; sys_platform == 'linux'",
-        "pynput~=1.16; sys_platform == 'linux'",
+        "pynput>=1.16; sys_platform == 'linux'",
         "pyobjc~=8.1; sys_platform == 'darwin'"
     ],
     keywords="gui window control menu title name geometry size position move resize minimize maximize restore "

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "pywin32>=302; sys_platform == 'win32'",
         "xlib~=0.21; sys_platform == 'linux'",
         "ewmh~=0.1; sys_platform == 'linux'",
-        "pynput>=1.16; sys_platform == 'linux'",
+        "pynput>=1.6.0; sys_platform == 'linux'",
         "pyobjc~=8.1; sys_platform == 'darwin'"
     ],
     keywords="gui window control menu title name geometry size position move resize minimize maximize restore "


### PR DESCRIPTION
I couldn't install `PyWinCtl` because of the `pynput` version (`1.16`) because the latest right now is `1.7.6`: https://pypi.org/project/pynput/#history

I set the minimum version to something recent that works for me

I'm looking forward to using `PyWinCtl`!