### PR TITLE
Type-checking and mark package as typed

### DIFF
--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -1,0 +1,47 @@
+name: Type Checking
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - "**/requirements.txt"
+      - "**/*.py"
+
+jobs:
+  pyright:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ["3.7", "3.11"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "docs/requirements.txt"
+      - run: pip install -r "docs/requirements.txt"
+      - uses: jakebailey/pyright-action@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+  mypy:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ["3.7", "3.11"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "docs/requirements.txt"
+      - run: pip install -r "docs/requirements.txt" mypy
+      - run: mypy .

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov/
 dist/
 build/
 *.egg-info/
+.vscode/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,19 @@
+# Requirements required for development
+# Run: `pip install -r docs/requirements.txt`
+# Production requirements are found in ../setup.py
+
 PyRect>=0.1
+types-setuptools>=65.5
+
+# Windows
 pywin32>=302; sys_platform == 'win32'
+types-pywin32>=304.0.0.3
+
+# Linux
 xlib>=0.21; sys_platform == 'linux'
 ewmh>=0.1; sys_platform == 'linux'
 pynput>=1.6; sys_platform == 'linux'
+types-pynput>=1.6
+
+# MacOS
 pyobjc>=8.1; sys_platform == 'darwin'

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,22 @@
+{
+  "typeCheckingMode": "basic",
+  // Extra strict. Optional options even in "strict" mode.
+  "reportImplicitStringConcatenation": "error",
+  "reportCallInDefaultInitializer": "error",
+  "reportPropertyTypeMismatch": "error",
+  "reportUninitializedInstanceVariable": "error",
+  "reportUnnecessaryTypeIgnoreComment": "warning",
+  // External libraries may be missing stubs
+  "reportMissingTypeStubs": "warning",
+  // False positives with TYPE_CHECKING
+  "reportImportCycles": "information",
+  // Extra runtime safety
+  "reportUnnecessaryComparison": "warning",
+  // As a library, we're allowed to use our own privates
+  "reportPrivateUsage": "none",
+  // Supporting common misused parameters from users that don't type-check is ok
+  "reportUnnecessaryIsInstance": "none",
+  // Keeping unused classes and functions for easier later reference
+  "reportUnusedClass": "none",
+  "reportUnusedFunction": "none",
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,14 @@
 [metadata]
 description_file = README.md
+
+[mypy]
+mypy_path = src/
+show_error_codes = True
+strict = False
+# Will be the default in mypy 0.990
+namespace_packages = True
+disable_error_code =
+  # Currently using non-strict typing
+  var-annotated,
+  # https://github.com/python/mypy/issues/6232
+  union-attr, attr-defined, assignment

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,12 @@ os.chdir(scriptFolder)
 
 # Find version info from module (without importing the module):
 with open("src/pywinctl/__init__.py", "r") as fileObj:
-    version = re.search(
+    match = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fileObj.read(), re.MULTILINE
-    ).group(1)
+    )
+    if not match:
+        raise TypeError("'__version__' not found in 'src/pywinctl/__init__.py'")
+    version = match.group(1)
 
 # Use the README.md content for the long description:
 with io.open("README.md", encoding="utf-8") as fileObj:
@@ -29,6 +32,7 @@ setup(
     license='BSD 3',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
+    package_data={"pywinctl": ["src/pywinctl/py.typed"]},
     test_suite='tests',
     install_requires=[
         "PyRect>=0.1",
@@ -39,7 +43,7 @@ setup(
         "pyobjc>=8.1; sys_platform == 'darwin'"
     ],
     keywords="gui window control menu title name geometry size position move resize minimize maximize restore "
-             "hide show activate raise lower close screen-size mouse-position",
+             + "hide show activate raise lower close screen-size mouse-position",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Win32 (MS Windows)',

--- a/src/pywinctl/py.typed
+++ b/src/pywinctl/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The pywinctl package uses inline types.

--- a/tests/test_MacNSWindow.py
+++ b/tests/test_MacNSWindow.py
@@ -5,16 +5,21 @@
 
 # We need to import the relevant object definitions from PyObjC
 
+import sys
+assert sys.platform == "darwin"
+
 import time
 
-from AppKit import *
+from AppKit import (  # type: ignore[import]
+    NSApp, NSObject, NSApplication, NSMakeRect, NSWindow, NSWindowStyleMaskTitled, NSWindowStyleMaskClosable,
+    NSWindowStyleMaskMiniaturizable, NSWindowStyleMaskResizable, NSBackingStoreBuffered)
 
-import pywinctl
+import pywinctl  # type: ignore[import]
 
 
 # Cocoa prefers composition to inheritance. The members of an object's
 # delegate will be called upon the happening of certain events. Once we define
-# methods with particular names, they will be called automatically 
+# methods with particular names, they will be called automatically
 class Delegate(NSObject):
 
     npw = None

--- a/tests/test_pywinctl.py
+++ b/tests/test_pywinctl.py
@@ -5,8 +5,7 @@ import subprocess
 import sys
 import time
 
-import pytest
-import pywinctl
+import pywinctl  # type: ignore[import]  # pyright: ignore[reportMissingImports]
 
 
 def test_basic():


### PR DESCRIPTION
Mark pywinctl as typed using the `py.typed` marker. See https://peps.python.org/pep-0561/
This allows static type checkers like pyright, mypy, pytype, pycharm, etc. to use inline types instead of looking for a non-existent type-stub.

I've added Github actions to validate typing using pyright and mypy.
Checking all python versions *may* be overkill. Testing only the oldest supported may be enough.
CI validation: https://github.com/Avasam/PyWinCtl/pull/1

And finally I've fixed any typing issue from basic type-checking.