### PR TITLE
Use types-python-xlib stub

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,6 +15,7 @@ xlib>=0.21; sys_platform == 'linux'
 ewmh>=0.1; sys_platform == 'linux'
 pynput>=1.6; sys_platform == 'linux'
 types-pynput>=1.6
+types-python-xlib>=0.32
 
 # MacOS
 pyobjc>=8.1; sys_platform == 'darwin'

--- a/src/pywinctl/__init__.py
+++ b/src/pywinctl/__init__.py
@@ -430,7 +430,7 @@ class BaseWindow(ABC):
 
     @property
     def topleft(self):
-        return cast(Point, self._rect.topleft) # pyrect.Rect.Point properties are potentially unknown
+        return cast(Point, self._rect.topleft)  # pyrect.Rect.Point properties are potentially unknown
 
     @topleft.setter
     def topleft(self, value: tuple[float, float]):
@@ -439,7 +439,7 @@ class BaseWindow(ABC):
 
     @property
     def topright(self):
-        return cast(Point, self._rect.topright) # pyrect.Rect.Point properties are potentially unknown
+        return cast(Point, self._rect.topright)  # pyrect.Rect.Point properties are potentially unknown
 
     @topright.setter
     def topright(self, value: tuple[float, float]):
@@ -448,7 +448,7 @@ class BaseWindow(ABC):
 
     @property
     def bottomleft(self):
-        return cast(Point, self._rect.bottomleft) # pyrect.Rect.Point properties are potentially unknown
+        return cast(Point, self._rect.bottomleft)  # pyrect.Rect.Point properties are potentially unknown
 
     @bottomleft.setter
     def bottomleft(self, value: tuple[float, float]):
@@ -457,7 +457,7 @@ class BaseWindow(ABC):
 
     @property
     def bottomright(self):
-        return cast(Point, self._rect.bottomright) # pyrect.Rect.Point properties are potentially unknown
+        return cast(Point, self._rect.bottomright)  # pyrect.Rect.Point properties are potentially unknown
 
     @bottomright.setter
     def bottomright(self, value: tuple[float, float]):
@@ -466,7 +466,7 @@ class BaseWindow(ABC):
 
     @property
     def midleft(self):
-        return cast(Point, self._rect.midleft) # pyrect.Rect.Point properties are potentially unknown
+        return cast(Point, self._rect.midleft)  # pyrect.Rect.Point properties are potentially unknown
 
     @midleft.setter
     def midleft(self, value: tuple[float, float]):
@@ -475,7 +475,7 @@ class BaseWindow(ABC):
 
     @property
     def midright(self):
-        return cast(Point, self._rect.midright) # pyrect.Rect.Point properties are potentially unknown
+        return cast(Point, self._rect.midright)  # pyrect.Rect.Point properties are potentially unknown
 
     @midright.setter
     def midright(self, value: tuple[float, float]):
@@ -493,7 +493,7 @@ class BaseWindow(ABC):
 
     @property
     def midbottom(self):
-        return cast(Point, self._rect.midbottom) # pyrect.Rect.Point properties are potentially unknown
+        return cast(Point, self._rect.midbottom)  # pyrect.Rect.Point properties are potentially unknown
 
     @midbottom.setter
     def midbottom(self, value: tuple[float, float]):
@@ -502,7 +502,7 @@ class BaseWindow(ABC):
 
     @property
     def center(self):
-        return cast(Point, self._rect.center) # pyrect.Rect.Point properties are potentially unknown
+        return cast(Point, self._rect.center)  # pyrect.Rect.Point properties are potentially unknown
 
     @center.setter
     def center(self, value: tuple[float, float]):
@@ -547,7 +547,7 @@ class BaseWindow(ABC):
 
     @property
     def size(self):
-        return cast(Size, self._rect.size) # pyrect.Rect.Size properties are potentially unknown
+        return cast(Size, self._rect.size)  # pyrect.Rect.Size properties are potentially unknown
 
     @size.setter
     def size(self, value: tuple[float, float]):
@@ -561,11 +561,11 @@ class BaseWindow(ABC):
     @area.setter
     def area(self, value: float):
         self._rect.area  # Run rect's onRead to update the Rect object.
-        self._rect.area = value # pyright: ignore[reportGeneralTypeIssues]  # FIXME: pyrect.Rect.area has no setter!
+        self._rect.area = value  # pyright: ignore[reportGeneralTypeIssues]  # FIXME: pyrect.Rect.area has no setter!
 
     @property
     def box(self):
-        return cast(Box, self._rect.box) # pyrect.Rect.Box properties are potentially unknown
+        return cast(Box, self._rect.box)  # pyrect.Rect.Box properties are potentially unknown
 
     @box.setter
     def box(self, value: Box):
@@ -653,22 +653,20 @@ class _WinWatchDog(threading.Thread):
             self._kill.wait(self._interval)
 
             try:
-                if sys.platform == "darwin":
-                    # In macOS AppScript version, if title changes, it will consider window is not alive anymore
-                    if self._isAliveCB or self._tryToFind:
-                        if not self._win.isAlive:
-                            if self._isAliveCB:
-                                self._isAliveCB(False)
-                            if self._tryToFind:
-                                title = self._win.title
-                                if self._title != title:
-                                    title = self._win.updatedTitle
-                                    self._title = title
-                                    if self._changedTitleCB:
-                                        self._changedTitleCB(title)
-                            if not self._tryToFind or (self._tryToFind and not self._title):
-                                self.kill()
-                            break
+                # In macOS AppScript version, if title changes, it will consider window is not alive anymore
+                if sys.platform == "darwin" and (self._isAliveCB or self._tryToFind) and not self._win.isAlive:
+                    if self._isAliveCB:
+                        self._isAliveCB(False)
+                    if self._tryToFind:
+                        title = self._win.title
+                        if self._title != title:
+                            title = self._win.updatedTitle
+                            self._title = title
+                            if self._changedTitleCB:
+                                self._changedTitleCB(title)
+                    if not self._tryToFind or (self._tryToFind and not self._title):
+                        self.kill()
+                    break
 
                 if self._isActiveCB:
                     active = self._win.isActive
@@ -753,22 +751,22 @@ class _WinWatchDog(threading.Thread):
 
     def setTryToFind(self, tryToFind: bool):
         if sys.platform == "darwin" and type(self._win).__name__ == Window.__name__:
-                self._tryToFind = tryToFind
+            self._tryToFind = tryToFind
 
     def kill(self):
         self._kill.set()
 
     def restart(
         self,
-        isAliveCB: Callable[[bool], None] | None  = None,
-        isActiveCB: Callable[[bool], None] | None  = None,
-        isVisibleCB: Callable[[bool], None] | None  = None,
-        isMinimizedCB: Callable[[bool], None] | None  = None,
-        isMaximizedCB: Callable[[bool], None] | None  = None,
-        resizedCB: Callable[[tuple[float, float]], None] | None  = None,
-        movedCB: Callable[[tuple[float, float]], None] | None  = None,
-        changedTitleCB: Callable[[str], None] | None  = None,
-        changedDisplayCB: Callable[[str], None] | None  = None,
+        isAliveCB: Callable[[bool], None] | None = None,
+        isActiveCB: Callable[[bool], None] | None = None,
+        isVisibleCB: Callable[[bool], None] | None = None,
+        isMinimizedCB: Callable[[bool], None] | None = None,
+        isMaximizedCB: Callable[[bool], None] | None = None,
+        resizedCB: Callable[[tuple[float, float]], None] | None = None,
+        movedCB: Callable[[tuple[float, float]], None] | None = None,
+        changedTitleCB: Callable[[str], None] | None = None,
+        changedDisplayCB: Callable[[str], None] | None = None,
         interval: float = 0.3
     ):
         self.kill()

--- a/src/pywinctl/_pywinctl_linux.py
+++ b/src/pywinctl/_pywinctl_linux.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
+
 import sys
 assert sys.platform == "linux"
 
@@ -15,19 +16,17 @@ import tkinter as tk
 import traceback
 from collections.abc import Callable
 from typing import Iterable
-from typing_extensions import TypedDict
 
 import ewmh
-# All of tehse errors will be fixed with a Xlib type-stub
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportGeneralTypeIssues=false, reportUnknownParameterType=false
-import Xlib.display  # type: ignore[import,reportMissingTypeStubs]
-import Xlib.error  # type: ignore[import,reportMissingTypeStubs]
-import Xlib.protocol  # type: ignore[import,reportMissingTypeStubs]
-import Xlib.X  # type: ignore[import,reportMissingTypeStubs]
-import Xlib.Xutil  # type: ignore[import,reportMissingTypeStubs]
-import Xlib.Xatom  # type: ignore[import,reportMissingTypeStubs]
+import Xlib.display
+import Xlib.error
+import Xlib.protocol
+import Xlib.X
+import Xlib.Xatom
+import Xlib.Xutil
 from pynput import mouse
-from Xlib.xobject.drawable import Window  # type: ignore[import,reportMissingTypeStubs]
+from typing_extensions import TypedDict
+from Xlib.xobject.drawable import Window
 
 from . import BaseWindow, Point, Re, Rect, Size, _WinWatchDog, pointInRect
 
@@ -410,7 +409,7 @@ class LinuxWindow(BaseWindow):
 
     def __init__(self, hWnd: Window):
         super().__init__()
-        self._hWnd: Window = hWnd
+        self._hWnd = hWnd
         self._parent: Window = self._hWnd.query_tree().parent
         self.__rect = self._rectFactory()
         # self._saveWindowInitValues()  # Store initial Window parameters to allow reset and other actions

--- a/src/pywinctl/_pywinctl_macos.py
+++ b/src/pywinctl/_pywinctl_macos.py
@@ -3,25 +3,26 @@
 # Incomplete type stubs for pyobjc
 # mypy: disable_error_code = no-any-return
 from __future__ import annotations
+
 import sys
 assert sys.platform == "darwin"
 
 import ast
 import difflib
 import platform
-import subprocess
 import re
+import subprocess
+import threading
 import time
 import traceback
-import threading
-from collections.abc import Iterable, Sequence, Callable
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, cast, overload
-from typing_extensions import TypeAlias, TypedDict, Literal
 
 import AppKit
 import Quartz
+from typing_extensions import Literal, TypeAlias, TypedDict
 
-from . import pointInRect, BaseWindow, Rect, Point, Size, Re, _WinWatchDog
+from . import BaseWindow, Point, Re, Rect, Size, _WinWatchDog, pointInRect
 
 Incomplete: TypeAlias = Any
 
@@ -223,9 +224,10 @@ def getWindowsWithTitle(title: str | re.Pattern[str], app: AppKit.NSApp | tuple[
     :param flags: (optional) specific flags to apply to condition. Defaults to 0 (no flags)
     :return: list of Window objects
     """
+    matches: list[MacOSWindow] = []
 
     if not (title and condition in Re._cond_dic):
-        return []  # pyright: ignore[reportUnknownVariableType]  # Type doesn't matter here
+        return matches
 
     lower = False
     if condition in (Re.MATCH, Re.NOTMATCH):
@@ -240,7 +242,6 @@ def getWindowsWithTitle(title: str | re.Pattern[str], app: AppKit.NSApp | tuple[
         title = title.lower()
 
     if app is None or isinstance(app, tuple):
-        matches: list[MacOSWindow] = []
         activeApps = _getAllApps()
         titleList = _getWindowTitles()
         for item in titleList:
@@ -1964,9 +1965,8 @@ class MacOSWindow(BaseWindow):
 
         def _getPathFromWid(self, wID: int):
             itemPath = []
-            if self._checkMenuStruct():
-                if 0 < wID <= len(self.itemList):
-                    itemPath = self.itemList[wID - 1].split(SEP)
+            if self._checkMenuStruct() and 0 < wID <= len(self.itemList):
+                itemPath = self.itemList[wID - 1].split(SEP)
             return itemPath
 
         def _getNewHSubMenu(self, ref: str):
@@ -1975,9 +1975,8 @@ class MacOSWindow(BaseWindow):
 
         def _getPathFromHSubMenu(self, hSubMenu: int):
             menuPath = []
-            if self._checkMenuStruct():
-                if 0 < hSubMenu <= len(self.menuList):
-                    menuPath = self.menuList[hSubMenu - 1].split(SEP)
+            if self._checkMenuStruct() and 0 < hSubMenu <= len(self.menuList):
+                menuPath = self.menuList[hSubMenu - 1].split(SEP)
             return menuPath
 
         def _getMenuItemWid(self, itemPath: str):

--- a/src/pywinctl/_pywinctl_win.py
+++ b/src/pywinctl/_pywinctl_win.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 from __future__ import annotations
+
 import sys
 assert sys.platform == "win32"
 
@@ -9,16 +10,16 @@ import re
 import threading
 import time
 import traceback
-from ctypes import wintypes
-from typing import TYPE_CHECKING, cast, overload, type_check_only
-from typing_extensions import NotRequired, TypedDict, Literal
 from collections import Callable, Sequence
+from ctypes import wintypes
+from typing import TYPE_CHECKING, cast, overload
 
 import win32api
 import win32con
 import win32gui
 import win32gui_struct
 import win32process
+from typing_extensions import Literal, NotRequired, TypedDict
 from win32com.client import GetObject
 
 from . import BaseWindow, Point, Re, Rect, Size, _WinWatchDog, pointInRect
@@ -293,30 +294,30 @@ def _getAllApps(tryToFilter: bool = False) -> list[tuple[int, str, str | None]] 
 def _getWindowInfo(hWnd: int | str | bytes | bool | None):
     class tagWINDOWINFO(ctypes.Structure):
         # Help type-checkers with ctypes.Structure
-        cbSize: int
-        rcWindow: wintypes.RECT
-        rcClient: wintypes.RECT
-        dwStyle: int
-        dwExStyle: int
-        dwWindowStatus: int
-        cxWindowBorders: int
-        cyWindowBorders: int
-        atomWindowType: int
-        wCreatorVersion: int
-        @type_check_only
-        def __init__(
-            self,
-            cbSize: int = ...,
-            rcWindow: wintypes.RECT = ...,
-            rcClient: wintypes.RECT = ...,
-            dwStyle: int = ...,
-            dwExStyle: int = ...,
-            dwWindowStatus: int = ...,
-            cxWindowBorders: int = ...,
-            cyWindowBorders: int = ...,
-            atomWindowType: int = ...,
-            wCreatorVersion: int = ...
-        ): ...
+        if TYPE_CHECKING:
+            cbSize: int
+            rcWindow: wintypes.RECT
+            rcClient: wintypes.RECT
+            dwStyle: int
+            dwExStyle: int
+            dwWindowStatus: int
+            cxWindowBorders: int
+            cyWindowBorders: int
+            atomWindowType: int
+            wCreatorVersion: int
+            def __init__(
+                self,
+                cbSize: int = ...,
+                rcWindow: wintypes.RECT = ...,
+                rcClient: wintypes.RECT = ...,
+                dwStyle: int = ...,
+                dwExStyle: int = ...,
+                dwWindowStatus: int = ...,
+                cxWindowBorders: int = ...,
+                cyWindowBorders: int = ...,
+                atomWindowType: int = ...,
+                wCreatorVersion: int = ...
+            ): ...
 
         _fields_ = [
             ('cbSize', wintypes.DWORD),

--- a/typings/ewmh/ewmh.pyi
+++ b/typings/ewmh/ewmh.pyi
@@ -7,8 +7,8 @@ from collections.abc import Iterable
 from typing import Any
 
 from typing_extensions import Literal, TypeAlias
-from Xlib.display import Display  # type: ignore[import,reportMissingTypeStubs]
-from Xlib.xobject.drawable import Window  # type: ignore[import,reportMissingTypeStubs]
+from Xlib.display import Display
+from Xlib.xobject.drawable import Window
 
 _GetAttrsProperty: TypeAlias = Literal[
     "_NET_CLIENT_LIST",


### PR DESCRIPTION
Stubs for Xlib are now available in typeshed. We can remove a bunch of `# type: ignore` comments.