### PR TITLE
Remove spurious print() leftover debug code from d3008ab

### DIFF
--- a/src/pywinctl/_pywinctl_linux.py
+++ b/src/pywinctl/_pywinctl_linux.py
@@ -427,7 +427,6 @@ class LinuxWindow(BaseWindow):
 
     def __init__(self, hWnd: Window | int | str):
         super().__init__()
-        print(type(hWnd))
         if isinstance(hWnd, int):
             self._hWnd = DISP.create_resource_object('window', hWnd)
         elif isinstance(hWnd, str):


### PR DESCRIPTION
this commit was previously included in #38, now made it independent so it can be merged separately while I fix the bugs in the other PRs