### PR TITLE
Fix XLib package name to its proper PyPi project

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ pywin32>=302; sys_platform == 'win32'
 types-pywin32>=305.0.0.3
 
 # Linux
-xlib>=0.21; sys_platform == 'linux'
+python-xlib>=0.21; sys_platform == 'linux'
 ewmh>=0.1; sys_platform == 'linux'
 types-python-xlib>=0.32
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         "PyRect>=0.2",
         "pywin32>=302; sys_platform == 'win32'",
-        "xlib>=0.21; sys_platform == 'linux'",
+        "python-xlib>=0.21; sys_platform == 'linux'",
         "ewmh>=0.1; sys_platform == 'linux'",
         "pyobjc>=8.1; sys_platform == 'darwin'"
     ],


### PR DESCRIPTION
The correct package is `python-xlib`, not `xlib`.
See https://stackoverflow.com/q/74716030/624066