### PR TITLE
include py.typed in wheel package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license='BSD 3',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
-    package_data={"pywinctl": ["src/pywinctl/py.typed"]},
+    package_data={"pywinctl": ["py.typed"]},
     test_suite='tests',
     install_requires=[
         "PyRect>=0.2",


### PR DESCRIPTION
`package_data` values for each package in `setup.py` are relative to each package, so `py.typed` was not included