### PR TITLE
Check for property WM_NAME if _NET_WM_NAME property does not return a value

### DIFF
--- a/src/ewmhlib/Props.py
+++ b/src/ewmhlib/Props.py
@@ -40,6 +40,7 @@ class DesktopLayout(IntEnum):
 
 class Window:
     NAME = "_NET_WM_NAME"
+    LEGACY_NAME = "WM_NAME"
     VISIBLE_NAME = "_NET_WM_VISIBLE_NAME"
     ICON_NAME = "_NET_WM_ICON_NAME"
     VISIBLE_ICON_NAME = "_NET_WM_VISIBLE_ICON_NAME"

--- a/src/ewmhlib/_ewmhlib.py
+++ b/src/ewmhlib/_ewmhlib.py
@@ -1068,6 +1068,10 @@ class EwmhWindow:
         res: Optional[Union[List[int], List[str]]] = getPropertyValue(ret, display=self.display)
         if res:
             return str(res[0])
+        ret: Optional[Xlib.protocol.request.GetProperty] = self.getProperty(Window.LEGACY_NAME)
+        res: Optional[Union[List[int], List[str]]] = getPropertyValue(ret, display=self.display)
+        if res:
+            return str(res[0])
         return None
 
     def setName(self, name: str):

--- a/src/ewmhlib/_ewmhlib.py
+++ b/src/ewmhlib/_ewmhlib.py
@@ -1068,8 +1068,8 @@ class EwmhWindow:
         res: Optional[Union[List[int], List[str]]] = getPropertyValue(ret, display=self.display)
         if res:
             return str(res[0])
-        ret: Optional[Xlib.protocol.request.GetProperty] = self.getProperty(Window.LEGACY_NAME)
-        res: Optional[Union[List[int], List[str]]] = getPropertyValue(ret, display=self.display)
+        ret = self.getProperty(Window.LEGACY_NAME)
+        res = getPropertyValue(ret, display=self.display)
         if res:
             return str(res[0])
         return None


### PR DESCRIPTION
It appears not all applications set the _NET_WM_NAME properety to set the window title.  _NET_WM_NAME should be preferred, but If not present, use the WM_NAME to retain compatibility with applications that do not set it.

Sources:
- https://specifications.freedesktop.org/wm-spec/latest/
- https://stackoverflow.com/questions/7706589/is-there-any-difference-with-the-x11-atoms-xa-wm-name-and-net-wm-name

modified:   src/ewmhlib/Props.py
Added the new Window.LEGACY_NAME="WM_NAME" property. This can be used to retain compatibility with older programs that do not set _NET_WM_NAME.

modified:   src/ewmhlib/_ewmhlib.py
Updated the logic for getName to now check for Window.LEGACY_NAME if the result of checking for Window.NAME does not return a value.