### PR TITLE
LINUX: Fix getAllMonitors() returns empty list if XDG_CURRENT_DESKTOP is not set

### DIFF
--- a/src/ewmhlib/_ewmhlib.py
+++ b/src/ewmhlib/_ewmhlib.py
@@ -42,7 +42,7 @@ def getDisplays(forceUpdate: bool = False) -> List[Xlib.display.Display]:
     global _displays
     if forceUpdate:
         _displays = []
-    if not _displays and os.environ['XDG_SESSION_TYPE'].lower() != "wayland":
+    if not _displays and os.environ.get('XDG_SESSION_TYPE', '').lower() != "wayland":
         # Wayland adds a "fake" display (typically ":1") that freezes when trying to get a connection. Using default
         # Thanks to SamuMazzi - https://github.com/SamuMazzi for pointing out this issue
         files: List[str] = os.listdir("/tmp/.X11-unix")
@@ -1044,7 +1044,7 @@ class EwmhWindow:
         self.ewmhRoot: EwmhRoot = defaultEwmhRoot if self.root.id == defaultRoot.id else EwmhRoot(self.root)
         self.extensions = _Extensions(self.id, self.display, self.root)
 
-        self._currDesktop = os.environ['XDG_CURRENT_DESKTOP'].lower()
+        self._currDesktop = os.environ.get('XDG_CURRENT_DESKTOP', '').lower()
 
     def getProperty(self, prop: Union[str, int], prop_type: int = Xlib.X.AnyPropertyType) \
             -> Optional[Xlib.protocol.request.GetProperty]:

--- a/src/pywinctl/_pywinctl_linux.py
+++ b/src/pywinctl/_pywinctl_linux.py
@@ -72,7 +72,7 @@ def getActiveWindow() -> Optional[LinuxWindow]:
     # https://discourse.gnome.org/t/get-window-id-of-a-window-object-window-get-xwindow-doesnt-exist/10956/3
     # https://www.reddit.com/r/gnome/comments/d8x27b/is_there_a_program_that_can_show_keypresses_on/
     win_id: Union[str, int] = 0
-    if os.environ['XDG_SESSION_TYPE'].lower() == "wayland":
+    if os.environ.get('XDG_SESSION_TYPE', '').lower() == "wayland":
         # swaymsg -t get_tree | jq '.. | select(.type?) | select(.focused==true).pid'  -> Not working (socket issue)
         # pynput / mouse --> Not working (no global events allowed, only application events)
         _, activeWindow = _WgetAllWindows()
@@ -113,7 +113,7 @@ def getAllWindows():
 
     :return: list of Window objects
     """
-    if os.environ['XDG_SESSION_TYPE'].lower() == "wayland":
+    if os.environ.get('XDG_SESSION_TYPE', '').lower() == "wayland":
         windowsList, _ = _WgetAllWindows()
         windows = [str(win["id"]) for win in windowsList if win and win.get("id", False)]
     else:
@@ -328,8 +328,8 @@ class LinuxWindow(BaseWindow):
         self._xWin: XWindow = self._win.xWindow
         self.watchdog = _WatchDog(self)
 
-        self._currDesktop = os.environ['XDG_CURRENT_DESKTOP'].lower()
-        self._currSessionType = os.environ['XDG_SESSION_TYPE'].lower()
+        self._currDesktop = os.environ.get('XDG_CURRENT_DESKTOP', '').lower()
+        self._currSessionType = os.environ.get('XDG_SESSION_TYPE', '').lower()
         self._motifHints: List[int] = []
 
     def getExtraFrameSize(self, includeBorder: bool = True) -> Tuple[int, int, int, int]:


### PR DESCRIPTION
If `XDG_CURRENT_DESKTOP` is not set, an exception will be thrown and `__remove_bad_windows()` will return an empty list.

`XDG_CURRENT_DESKTOP` is only set in large integrated desktop environments and not in small Window Managers.
Therefore, the correct list must be returned even if the environment variable is not set.