### PR TITLE
Fix client frame computation accounting for PyWinBox change

### DIFF
--- a/src/pywinctl/_pywinctl_linux.py
+++ b/src/pywinctl/_pywinctl_linux.py
@@ -365,8 +365,8 @@ class LinuxWindow(BaseWindow):
         if _net_extents and len(_net_extents) >= 4:
             x = x + int(_net_extents[0])
             y = y + int(_net_extents[2])
-            w = w - int(_net_extents[0]) + int(_net_extents[1])
-            h = h - int(_net_extents[2]) + int(_net_extents[3])
+            w = w - int(_net_extents[0]) - int(_net_extents[1])
+            h = h - int(_net_extents[2]) - int(_net_extents[3])
             ret = Rect(x, y, x + w, y + h)
         else:
             # TODO: Find a way to find window title and borders sizes in GNOME


### PR DESCRIPTION
Goes hand-in-hand with https://github.com/Kalmat/PyWinBox/pull/2

This fixes getClientFrame for GTK HeaderBar-free applications.

There is still no way (?) to get the ClientArea for applications with GTK HeaderBar. But at least we're getting the tight bounding box around the window now.

See the other PR for more description.