### PR TITLE
Fix MacOSWindow.isAlive on recent macOS

### DIFF
--- a/src/pywinctl/_pywinctl_macos.py
+++ b/src/pywinctl/_pywinctl_macos.py
@@ -1299,7 +1299,8 @@ class MacOSWindow(BaseWindow):
                         set isDone to false
                         try
                             tell application "System Events" to tell application "%s"
-                                tell window winName to set prevIndex to index
+                                tell window winName
+                                end tell
                                 set isDone to true
                             end tell
                         end try


### PR DESCRIPTION
I'm not sure since when, but at least on Ventura 13.6.3 "tell window winName to set prevIndex to index" causes the try block to exit, causing isDone to be left to False.
Just having a "tell window" seems to be enough here.
On a side note, raiseWindow and lowerWindow are also broken since setting "index" doesn't seem to work anymore, but I have no idea how to fix it. isAlive being False causes issues in general so I think this should be fixed at least