### PR TITLE
Add missing CI tests + Fix Watchdog racing condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: python test_pywinctl.py
 
   sphinx:
-    runs-on: ubuntu-lts-latest # Keep in sync with build.os in .readthedocs.yaml
+    runs-on: ubuntu-24.04-arm # Keep in sync with build.os in .readthedocs.yaml
     timeout-minutes: *timeout-minutes
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,22 @@ on:
       - "setup.cfg"
       - "**/*.py"
 
+concurrency:
+  # Cancel previous runs for the same PR
+  # Don't cancel successive pushes to master
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   mypy:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: &timeout-minutes 5
     strategy:
+      # mypy is os and python-version sensitive. Test on all supported combinations
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
+        # Arm runners are faster (as long as the same wheels are available)
+        os: [windows-11-arm, ubuntu-24.04-arm, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
@@ -38,15 +47,50 @@ jobs:
       - run: uv sync --locked
       - run: mypy . --python-version=${{ matrix.python-version }}
 
+  tests:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: *timeout-minutes
+    strategy:
+      # Test on all supported runtime combinations
+      matrix:
+        # Arm runners are faster (as long as the same wheels are available)
+        # PyWinCtl doesn't have any code that should act differently per architecture
+        os: [windows-11-arm, ubuntu-24.04-arm, macos-latest]
+        # TODO: Run tests in parallel on free-threaded python to catch free-threading issues
+        # See: https://py-free-threading.github.io/testing/
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Linux Packages
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt update
+          sudo apt install gedit xvfb x11-xserver-utils openbox dbus-x11
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
+      - run: uv sync --locked
+      - name: Run tests (Linux)
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        working-directory: tests
+        run: xvfb-run --server-args="-screen 0 1280x1024x24" bash -c "openbox & sleep 1 && dbus-launch --exit-with-session python test_pywinctl.py"
+      - name: Run tests (Windows & macOS)
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+        working-directory: tests
+        run: python test_pywinctl.py
+
   sphinx:
-    runs-on: ubuntu-22.04 # Keep in sync with build.os in .readthedocs.yaml
+    runs-on: ubuntu-lts-latest # Keep in sync with build.os in .readthedocs.yaml
+    timeout-minutes: *timeout-minutes
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.2.0
         with:
-          python-version: "3.11" # Keep in sync with build.tools.python in .readthedocs.yaml
+          python-version: "3.14" # Keep in sync with build.tools.python in .readthedocs.yaml
           activate-environment: true
       - run: uv sync --locked --no-default-groups --group=docs
       - name: Build docs
         # TODO: Add --fail-on-warning, but still too many warnings right now
-        run: sphinx-build --keep-going -b html docs/source docs/_build/html
+        run: sphinx-build --keep-going --builder html docs/source docs/_build/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,9 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04 # Keep in sync with runs-on in .github/workflows/docs.yml
+  os: ubuntu-lts-latest # Keep in sync with runs-on in .github/workflows/ci.yml
   tools:
-    python: "3.11" # Keep in sync with python-version in .github/workflows/docs.yml
+    python: "3.14" # Keep in sync with python-version in .github/workflows/ci.yml
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-lts-latest # Keep in sync with runs-on in .github/workflows/ci.yml
+  os: ubuntu-24.04 # Keep in sync with runs-on in .github/workflows/ci.yml
   tools:
     python: "3.14" # Keep in sync with python-version in .github/workflows/ci.yml
     # You can also specify other tool versions:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+0.4.02, 2026/06/16 -- ALL: Fixed WatchDog.stop() not joining the worker thread. Known to have been causing Xlib race conditions on Linux
 0.4.01, 2024/09/22 -- ALL: Added getAllWindowsDict() general function. Added getPID() method.
                       LINUX: Added bad window filter to check for window.id == 0
 0.4, 2023/10/11 -- ALL: Added getMonitor() as alias for getDisplay()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PyWinCtl <a name="pywinctl"></a>
-[![Type Checking](https://github.com/Kalmat/PyWinCtl/actions/workflows/type-checking.yml/badge.svg?branch=dev)](https://github.com/Kalmat/PyWinCtl/actions/workflows/type-checking.yml)
+[![CI](https://github.com/Kalmat/PyWinCtl/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/Kalmat/PyWinCtl/actions/workflows/ci.yml)
 [![PyPI version](https://badge.fury.io/py/PyWinCtl.svg)](https://badge.fury.io/py/PyWinCtl)
 [![Documentation Status](https://readthedocs.org/projects/pywinctl/badge/?version=latest)](https://pywinctl.readthedocs.io/en/latest/?badge=latest)
 [![Downloads](https://static.pepy.tech/badge/pywinctl/month)](https://pepy.tech/project/pywinctl)

--- a/TODO.txt
+++ b/TODO.txt
@@ -38,4 +38,4 @@ macOS / NSWindow:
 
 General:
 - [Type_check] PyRect: Create type stubs or add to base library
-- [Type_check] Return to "full" type-checking.yml version
+- [Type_check] Add back pyright (for PyLance) type checking in ci.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "ewmhlib>=0.2; sys_platform == 'linux'",

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 description_file = README.md
 
 [mypy]
-python_version = 3.9
 mypy_path = src/, typings/
 exclude = build
 strict = True
@@ -19,5 +18,3 @@ warn_unused_ignores = False
 disable_error_code =
   # https://github.com/python/mypy/issues/6232 (redefinition with correct type)
   attr-defined, assignment,
-  # https://github.com/python/mypy/issues/13975 (@property mistaken as Callable)
-  comparison-overlap, truthy-function

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setup(
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.11',
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/src/pywinctl/_main.py
+++ b/src/pywinctl/_main.py
@@ -582,6 +582,7 @@ class _WatchDog:
         """
         if self._watchdog:
             self._watchdog.kill()
+            self._watchdog.join()
 
     def isAlive(self):
         """Check if watchdog is running

--- a/tests/test_pywinctl.py
+++ b/tests/test_pywinctl.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 import subprocess
 import sys
 import time
+from typing import TypedDict
 
 import pywinctl
+
+
+class GetWindowKwargs(TypedDict):
+    title: str
+    condition: int  # TODO: Consider making pywinctl.Re an IntEnum
 
 
 def test_basic():
@@ -26,52 +32,41 @@ def test_basic():
     print()
 
     if sys.platform == "win32":
-        subprocess.Popen('notepad')
-        time.sleep(2)
-
-        testWindows = [pywinctl.getActiveWindow()]
-        assert len(testWindows) == 1
-
-        npw = testWindows[0]
-        wait = True
-        timelap = 0.50
-
-        basic_test(npw, wait, timelap)
-
+        process = "notepad"
+        get_window_kwargs: GetWindowKwargs = {
+            "title": "Notepad",
+            "condition": pywinctl.Re.ENDSWITH,
+        }
     elif sys.platform == "linux":
-        subprocess.Popen('gedit')
-        time.sleep(2)
-
-        testWindows = [pywinctl.getActiveWindow()]
-        assert len(testWindows) == 1
-
-        npw = testWindows[0]
-        wait = True
-        timelap = 0.50
-
-        basic_test(npw, wait, timelap)
-
+        process = "gedit"
+        get_window_kwargs: GetWindowKwargs = {
+            "title": "gedit",
+            "condition": pywinctl.Re.ENDSWITH,
+        }
     elif sys.platform == "darwin":
         if not pywinctl.checkPermissions(activate=True):
             exit()
-        subprocess.Popen(['touch', 'test.py'])
-        time.sleep(2)
-        subprocess.Popen(['open', '-a', 'TextEdit', 'test.py'])
-        time.sleep(5)
-
-        testWindows = pywinctl.getWindowsWithTitle('test.py')
-        assert len(testWindows) == 1
-
-        npw = testWindows[0]
-        wait = True
-        timelap = 0.50
-
-        basic_test(npw, wait, timelap)
-        subprocess.Popen(['rm', 'test.py'])
-
+        process = ["open", "-a", "TextEdit", __file__]
+        get_window_kwargs: GetWindowKwargs = {
+            "title": "test_pywinctl.py",
+            "condition": pywinctl.Re.IS,
+        }
     else:
-        raise NotImplementedError('PyWinCtl currently does not support this platform. If you have useful knowledge, please contribute! https://github.com/Kalmat/pywinctl')
+        raise NotImplementedError(
+            "PyWinCtl currently does not support this platform. "
+            + "If you have useful knowledge, please contribute! https://github.com/Kalmat/PyWinCtl"
+        )
 
+    subprocess.Popen(process)
+
+    testWindows: list[pywinctl.Window] = []
+    deadline = time.time() + 15
+    while not testWindows and time.time() < deadline:
+        time.sleep(0.5)
+        testWindows = pywinctl.getWindowsWithTitle(**get_window_kwargs)
+    assert len(testWindows) == 1
+
+    basic_test(npw=testWindows[0], wait=True, timelap=0.50)
 
 def basic_test(npw: pywinctl.Window | None, wait: bool, timelap: float):
     assert npw is not None
@@ -249,8 +244,9 @@ def basic_test(npw: pywinctl.Window | None, wait: bool, timelap: float):
     print("PARENT INFO")
     parent = npw.getParent()
     if parent:
-        print("WINDOW PARENT:", parent, npw.isChild(parent))
-        assert npw.isChild(parent)
+        is_child = npw.isChild(parent)
+        print("WINDOW PARENT:", parent, is_child)
+        assert is_child
     children = npw.getChildren()
     for child in children:
         if child and isinstance(child, int):


### PR DESCRIPTION
- mypy is os and python-version sensitive. Test on all supported combinations
  - If you don't want to run a full matrix, we should at least do oldest + newest python versions supported as to cover the extreme ends of the range.
- Added github action concurrency cancellation
- Added missing runtime tests
- ~~Added missing and sphinx tests.~~ (done in https://github.com/Kalmat/PyWinCtl/pull/98)
- Fixed and simplified some flaky tests.
- Fixed a potential racing condition in Watchdog

---

Edit: Already done in previous PR
~~I think you should enable `Build pull requests for this project` in https://app.readthedocs.org/dashboard/pywinctl/edit/~~
~~See: https://docs.readthedocs.com/platform/stable/pull-requests.html~~
~~(Sphinx test can fail sooner directly in CI, RTD PR validation can catch specifics to RTD)~~

