### PR TITLE
Avoid bare except

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
-0.4.02, 2026/06/16 -- ALL: Fixed WatchDog.stop() not joining the worker thread. Known to have been causing Xlib race conditions on Linux
+0.4.02, 2026/06/16 -- ALL: Replaced bare `except:` clauses with `except Exception:`, preventing accidental suppression of system-exit signals (KeyboardInterrupt, SystemExit) during error handling.
+                      ALL: Fixed WatchDog.stop() not joining the worker thread. Known to have been causing Xlib race conditions on Linux
 0.4.01, 2024/09/22 -- ALL: Added getAllWindowsDict() general function. Added getPID() method.
                       LINUX: Added bad window filter to check for window.id == 0
 0.4, 2023/10/11 -- ALL: Added getMonitor() as alias for getDisplay()

--- a/ruff.toml
+++ b/ruff.toml
@@ -38,7 +38,6 @@ ignore = [
   # TODO: Consider later
   "UP031", # printf-string-formatting
   "RUF059", # unused-unpacked-variable
-  "E722", # bare-except
 ]
 # F401 would remove imports not marked as explicit re-exports, which may break API boundaries
 extend-unsafe-fixes = ["F401"]

--- a/src/pywinctl/_main.py
+++ b/src/pywinctl/_main.py
@@ -591,7 +591,7 @@ class _WatchDog:
         """
         try:
             alive = bool(self._watchdog and self._watchdog.is_alive())
-        except:
+        except Exception:
             alive = False
         return alive
 
@@ -663,7 +663,7 @@ class _WatchDogWorker(threading.Thread):
 
             if self._changedDisplayCB:
                 self._display = self._win.getDisplay()
-        except:
+        except Exception:
             if self._isAliveCB:
                 self._isAliveCB(False)
             self.kill()
@@ -744,7 +744,7 @@ class _WatchDogWorker(threading.Thread):
                     if self._display != display:
                         self._display = display
                         self._changedDisplayCB(display)
-            except:
+            except Exception:
                 if self._isAliveCB:
                     self._isAliveCB(False)
                 self.kill()

--- a/src/pywinctl/_pywinctl_linux.py
+++ b/src/pywinctl/_pywinctl_linux.py
@@ -369,7 +369,7 @@ def __remove_bad_windows(windows: list[str] | list[int] | None) -> list[LinuxWin
                 # Thanks to Seraphli (https://github.com/Seraphli) for pointing out this issue!
                 if window:
                     outList.append(LinuxWindow(window))
-            except:
+            except Exception:
                 pass
     return outList
 

--- a/src/pywinctl/_pywinctl_macos.py
+++ b/src/pywinctl/_pywinctl_macos.py
@@ -133,7 +133,7 @@ def getAllWindows() -> list[MacOSWindow]:
         try:
             pID = item[0]
             title = item[1]
-        except:
+        except Exception:
             continue
         for activeApp in activeApps:
             if activeApp.processIdentifier() == pID:
@@ -465,10 +465,10 @@ def _getWindowTitles() -> list[list[str]]:
                         pos = res[1][1][i][j]
                         size = res[1][2][i][j]
                         result.append([pID, title, pos, size])
-                    except:
+                    except Exception:
                         pass
                     j += 1
-            except:
+            except Exception:
                 pass
     return result
 
@@ -1856,19 +1856,19 @@ class MacOSWindow(BaseWindow):
 
             try:
                 key = item_info["AXMenuItemCmdChar"]["value"]
-            except:
+            except Exception:
                 key = ""
             try:
                 modifiers = int(item_info["AXMenuItemCmdModifiers"]["value"])
-            except:
+            except Exception:
                 modifiers = -1
             try:
                 glyph = int(item_info["AXMenuItemCmdGlyph"]["value"])
-            except:
+            except Exception:
                 glyph = -1
             try:
                 virtual_key = int(item_info["AXMenuItemCmdVirtualKey"]["value"])
-            except:
+            except Exception:
                 virtual_key = -1
 
             modifiers_type = ""

--- a/src/pywinctl/_pywinctl_win.py
+++ b/src/pywinctl/_pywinctl_win.py
@@ -93,7 +93,7 @@ def __remove_bad_windows(windows: list[int] | None):
         for window in windows:
             try:
                 outList.append(Win32Window(window))
-            except:
+            except Exception:
                 pass
     return outList
 
@@ -460,7 +460,7 @@ def _getWindowInfo(hWnd: int | str | bytes | bool | None) -> tagWINDOWINFO:
     wi.cbSize = ctypes.sizeof(wi)
     try:
         ctypes.windll.user32.GetWindowInfo(hWnd, ctypes.byref(wi))
-    except:
+    except Exception:
         pass
 
     # None of these seem to return the right value, at least not in my system, but might be useful for other metrics
@@ -521,7 +521,7 @@ class Win32Window(BaseWindow):
             try:
                 xBorder = ctypes.windll.user32.GetSystemMetrics(win32con.SM_CXBORDER)
                 yBorder = ctypes.windll.user32.GetSystemMetrics(win32con.SM_CYBORDER)
-            except:
+            except Exception:
                 xBorder = 1
                 yBorder = 1
             xOffset -= xBorder
@@ -644,7 +644,7 @@ class Win32Window(BaseWindow):
         """
         try:
             win32gui.SetForegroundWindow(self._hWnd)
-        except:
+        except Exception:
             pass
         return self.isActive
 
@@ -1019,7 +1019,7 @@ class Win32Window(BaseWindow):
     #                 desc: str = win32api.GetFileVersionInfo(exeName, stringFileInfo)  # type: ignore[func-returns-value]
     #                 if desc:
     #                     description = desc
-    #         except:
+    #         except Exception:
     #             pass
     #         return description
     #
@@ -1040,7 +1040,7 @@ class Win32Window(BaseWindow):
     #             w: pywinauto.WindowSpecification = sysTray.child_window(title_re=name, found_index=0)
     #             ret: Rect = w.rectangle()
     #             return Rect(ret.left, ret.top, ret.right, ret.bottom)
-    #         except:
+    #         except Exception:
     #             return None
     #
     #     def _intToRGBA(color: int) -> Tuple[int, int, int, int]:


### PR DESCRIPTION
Replaced bare `except:` clauses with `except Exception:`, preventing accidental suppression of system-exit signals (`KeyboardInterrupt`, `SystemExit`) during error handling. Which is almost never intended.